### PR TITLE
fix: default env file

### DIFF
--- a/test/action.yml
+++ b/test/action.yml
@@ -23,7 +23,7 @@ inputs:
   env_file:
     description: "The path of the .env file"
     required: false
-    default: ".env.example"
+    default: ".env"
 
 runs:
   using: "composite"


### PR DESCRIPTION
fix

- el archivo `.env.example` esta sobrescribiendo las variables de entorno de github.